### PR TITLE
adding demonstration on how to use the base object MeshAmalgamation

### DIFF
--- a/include/EqualNeighborHeuristic.h
+++ b/include/EqualNeighborHeuristic.h
@@ -8,9 +8,10 @@ class EqualNeighborHeuristic : public MeshAmalgamation {
 protected:
     double _tol =0.000001;
 public:
-    EqualNeighborHeuristic(libMesh::Mesh &mesh, libMesh::EquationSystems &equation_system,
-              std::string system_name)
-      : MeshAmalgamation(mesh, equation_system, system_name) {}
+    EqualNeighborHeuristic(libMesh::Mesh &mesh,
+                           libMesh::EquationSystems &equation_system,
+                           const std::string system_name,const std::string variable_name)
+      : MeshAmalgamation(mesh,equation_system,system_name,variable_name) {}
 
   bool belongToCluster(libMesh::Elem *elem,
                        libMesh::Elem *neighbor_elem) override;

--- a/include/MeshAmalgamationBase.h
+++ b/include/MeshAmalgamationBase.h
@@ -2,20 +2,20 @@
 #define MESHAMALGAMATION_H
 
 #include <cstdlib>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 namespace libMesh {
-    class DofMap;
-    class Elem;
-    class EquationSystems;
-    class LinearImplicitSystem;
-    class Mesh;
-    class NumericVector;
-    class System;
-}
+class DofMap;
+class Elem;
+class EquationSystems;
+class LinearImplicitSystem;
+class Mesh;
+class NumericVector;
+class System;
+} // namespace libMesh
 
-class MeshAmalgamation{
+class MeshAmalgamation {
 
 private:
 protected:
@@ -23,7 +23,7 @@ protected:
   unsigned int _extra_element_integer_index;
   unsigned int _variable_index;
   std::string _system_name;
-  unsigned int _number_of_colors= 12;
+  unsigned int _number_of_colors = 12;
 
   libMesh::Mesh &_mesh;
   libMesh::EquationSystems &_equation_system;
@@ -33,9 +33,10 @@ protected:
   double getElementDataFromMesh(const libMesh::Elem *elem);
 
 public:
-    MeshAmalgamation(libMesh::Mesh &mesh,
-                     libMesh::EquationSystems &equation_system,
-                     const std::string system_name,const std::string variable_name);
+  MeshAmalgamation(libMesh::Mesh &mesh,
+                   libMesh::EquationSystems &equation_system,
+                   const std::string system_name,
+                   const std::string variable_name);
 
   virtual bool belongToCluster(libMesh::Elem *elem,
                                libMesh::Elem *neighbor_elem) = 0;

--- a/include/MeshAmalgamationBase.h
+++ b/include/MeshAmalgamationBase.h
@@ -33,9 +33,9 @@ protected:
   double getElementDataFromMesh(const libMesh::Elem *elem);
 
 public:
-  MeshAmalgamation(libMesh::Mesh &mesh,
-                   libMesh::EquationSystems &equation_system,
-                   std::string system_name);
+    MeshAmalgamation(libMesh::Mesh &mesh,
+                     libMesh::EquationSystems &equation_system,
+                     const std::string system_name,const std::string variable_name);
 
   virtual bool belongToCluster(libMesh::Elem *elem,
                                libMesh::Elem *neighbor_elem) = 0;

--- a/src/MeshAmalgamationBase.cpp
+++ b/src/MeshAmalgamationBase.cpp
@@ -12,12 +12,13 @@
 
 MeshAmalgamation::MeshAmalgamation(libMesh::Mesh &mesh,
                                    libMesh::EquationSystems &equation_system,
-                                   const std::string system_name)
+                                   const std::string system_name,const std::string variable_name)
     : _mesh(mesh), _equation_system(equation_system),
       _system_name(system_name),
-    _system (_equation_system.add_system<libMesh::LinearImplicitSystem>(_system_name)),
+    _system (_equation_system.get_system<libMesh::LinearImplicitSystem>(_system_name)),
     _dof_map (_system.get_dof_map()){
-
+    _variable_name = variable_name;
+    _variable_index = _system.variable_number(_variable_name);
 }
 
 void MeshAmalgamation::findCluster() {

--- a/src/MeshAmalgamationBase.cpp
+++ b/src/MeshAmalgamationBase.cpp
@@ -15,7 +15,7 @@ MeshAmalgamation::MeshAmalgamation(libMesh::Mesh &mesh,
                                    const std::string system_name)
     : _mesh(mesh), _equation_system(equation_system),
       _system_name(system_name),
-    _system (_equation_system.add_system<LinearImplicitSystem>(_system_name)),
+    _system (_equation_system.add_system<libMesh::LinearImplicitSystem>(_system_name)),
     _dof_map (_system.get_dof_map()){
 
 }

--- a/test_cases/testEqualNeighborHeuristic.cpp
+++ b/test_cases/testEqualNeighborHeuristic.cpp
@@ -46,6 +46,7 @@ int main(int argc, char **argv){
      * and I am fully aware what is the name and type of the system (for now we are only allowing LinearImplicitSystem)
      * which solution field (name of the variable) should be */
     EqualNeighborHeuristic demo (mesh,equation_system,"random_solution_field","random_data");
+    demo.setTolerance(0.001);
     demo.findCluster();
     demo.captureClusterID();
     demo.writeOutputData("output.e");

--- a/test_cases/testEqualNeighborHeuristic.cpp
+++ b/test_cases/testEqualNeighborHeuristic.cpp
@@ -5,13 +5,13 @@
 
 #include "libmesh/mesh_generation.h"
 #include "libmesh/libmesh.h"
-#include "MeshAmalgamationBase.h"
+#include "EqualNeighborHeuristic.h"
 
-class testMeshAmalgamation:public MeshAmalgamation{
+class testEqualNeighborHeuristic:public EqualNeighborHeuristic{
 public:
-    testMeshAmalgamation(libMesh::Mesh &mesh,
+    testEqualNeighborHeuristic(libMesh::Mesh &mesh,
                             libMesh::EquationSystems &equation_system,
-                            std::string system_name): MeshAmalgamation(mesh, equation_system, system_name) {}
+                            std::string system_name): EqualNeighborHeuristic(mesh, equation_system, system_name) {}
 
     void populateRandomData(){
         std::vector<libMesh::dof_id_type> dof_indices;
@@ -22,8 +22,6 @@ public:
         }
         _system.solution->close();
     }
-    bool belongToCluster(libMesh::Elem *elem,libMesh::Elem *neighbor_elem){return true;}
-    //this won't be used at all for this demonstration
 };
 
 int main(int argc, char **argv){
@@ -35,9 +33,11 @@ int main(int argc, char **argv){
     libMesh::MeshTools::Generation::build_square(mesh, nx, ny, -10.0, 10.0, -10.0,10.0);
     libMesh::EquationSystems equation_system(mesh);
 
-    testMeshAmalgamation demo (mesh,equation_system,"testMeshAmalgamation_field");
+    testEqualNeighborHeuristic demo (mesh,equation_system,"EqualNeighborHeuristic_field");
     demo.addVariableToSystem("random_data");
     demo.populateRandomData();
-    demo.writeOutputData("testMeshAmalgamation.e");
+    demo.findCluster();
+    demo.captureClusterID();
+    demo.writeOutputData("testEqualNeighborHeuristic.e");
 }
 

--- a/test_cases/testEqualNeighborHeuristic.cpp
+++ b/test_cases/testEqualNeighborHeuristic.cpp
@@ -42,6 +42,9 @@ int main(int argc, char **argv){
     PopulateRandomIntegers(mesh,system);
 
     //actual clustering process
+    /* Now the framework presumes I have the mesh and equation_system
+     * and I am fully aware what is the name and type of the system (for now we are only allowing LinearImplicitSystem)
+     * which solution field (name of the variable) should be */
     EqualNeighborHeuristic demo (mesh,equation_system,"random_solution_field","random_data");
     demo.findCluster();
     demo.captureClusterID();

--- a/test_cases/testEqualNeighborHeuristic.cpp
+++ b/test_cases/testEqualNeighborHeuristic.cpp
@@ -3,52 +3,62 @@
 #include <ctime>
 #include <random>
 
-#include "libmesh/mesh_generation.h"
-#include "libmesh/libmesh.h"
 #include "EqualNeighborHeuristic.h"
+#include "libmesh/libmesh.h"
+#include "libmesh/mesh_generation.h"
 
-void PopulateRandomIntegers(libMesh::Mesh &mesh, libMesh::LinearImplicitSystem &system) {
-    libMesh::DofMap &dof_map = system.get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    for (const auto &elem : mesh.element_ptr_range()) {
+void PopulateRandomIntegers(libMesh::Mesh &mesh,
+                            libMesh::LinearImplicitSystem &system) {
+  libMesh::DofMap &dof_map = system.get_dof_map();
+  std::vector<libMesh::dof_id_type> dof_indices;
+  for (const auto &elem : mesh.element_ptr_range()) {
 
-        dof_map.dof_indices(elem, dof_indices);
-        int random_int = rand() % 5;
-        system.solution->set(dof_indices[0], 5 - random_int);
-    }
-    system.solution->close();
+    dof_map.dof_indices(elem, dof_indices);
+    int random_int = rand() % 5;
+    system.solution->set(dof_indices[0], 5 - random_int);
+  }
+  system.solution->close();
 }
 
 void AddVariableToSystem(libMesh::EquationSystems &equation_system,
-                          libMesh::LinearImplicitSystem &system, std::string var_name,
-                          bool needs_re_init = false) {
-    system.add_variable(var_name, libMesh::CONSTANT, libMesh::MONOMIAL);
-    if (!needs_re_init) {
-        equation_system.init();
-    } else {
-        equation_system.reinit();
-    }
+                         libMesh::LinearImplicitSystem &system,
+                         std::string var_name, bool needs_re_init = false) {
+  system.add_variable(var_name, libMesh::CONSTANT, libMesh::MONOMIAL);
+  if (!needs_re_init) {
+    equation_system.init();
+  } else {
+    equation_system.reinit();
+  }
 }
-int main(int argc, char **argv){
-    //preparing the mesh and the data
-    libMesh::LibMeshInit init(argc, argv);
-    libMesh::Mesh mesh(init.comm());
-    unsigned int nx = 5;
-    unsigned int ny = 5;
-    libMesh::MeshTools::Generation::build_square(mesh, nx, ny, -10.0, 10.0, -10.0,10.0);
-    libMesh::EquationSystems equation_system(mesh);
-    libMesh::LinearImplicitSystem &system =equation_system.add_system<libMesh::LinearImplicitSystem>("random_solution_field");
-    AddVariableToSystem(equation_system,system,"random_data");
-    PopulateRandomIntegers(mesh,system);
+int main(int argc, char **argv) {
+  //declaring the system name and variable_name
+  //variable_name would be the variable based on which heuristics would be done
+  std::string name_of_the_system = "random_solution_field";
+  std::string populated_varibale_name = "random_data";
 
-    //actual clustering process
-    /* Now the framework presumes I have the mesh and equation_system
-     * and I am fully aware what is the name and type of the system (for now we are only allowing LinearImplicitSystem)
-     * which solution field (name of the variable) should be */
-    EqualNeighborHeuristic demo (mesh,equation_system,"random_solution_field","random_data");
-    demo.setTolerance(0.001);
-    demo.findCluster();
-    demo.captureClusterID();
-    demo.writeOutputData("output.e");
+  // preparing the mesh and the data
+  libMesh::LibMeshInit init(argc, argv);
+  libMesh::Mesh mesh(init.comm());
+  unsigned int nx = 5;
+  unsigned int ny = 5;
+  libMesh::MeshTools::Generation::build_square(mesh, nx, ny, -10.0, 10.0, -10.0,
+                                               10.0);
+  libMesh::EquationSystems equation_system(mesh);
+  libMesh::LinearImplicitSystem &system =
+      equation_system.add_system<libMesh::LinearImplicitSystem>(
+          name_of_the_system);
+  AddVariableToSystem(equation_system, system, populated_varibale_name);
+  PopulateRandomIntegers(mesh, system);
+
+  // actual clustering process
+  /* Now the framework presumes I have the mesh and equation_system
+   * and I am fully aware what is the name and type of the system (for now we
+   * are only allowing LinearImplicitSystem) which solution field (name of the
+   * variable) should be */
+  EqualNeighborHeuristic demo(mesh, equation_system, name_of_the_system,
+                              populated_varibale_name);
+  demo.setTolerance(0.001);
+  demo.findCluster();
+  demo.captureClusterID();
+  demo.writeOutputData("output.e");
 }
-

--- a/test_cases/testEqualNeighborHeuristic.cpp
+++ b/test_cases/testEqualNeighborHeuristic.cpp
@@ -8,11 +8,24 @@
 #include "libmesh/mesh_generation.h"
 
 void PopulateRandomIntegers(libMesh::Mesh &mesh,
-                            libMesh::LinearImplicitSystem &system) {
+                            libMesh::EquationSystems &equation_system,
+                            const std::string system_name,
+                            const std::string variable_name,needs_re_init=false) {
+
+  libMesh::LinearImplicitSystem system =
+      equation_system.add_system<libMesh::LinearImplicitSystem>(system_name);
+
+  system.add_variable(variable_name, libMesh::CONSTANT, libMesh::MONOMIAL);
+  if (needs_re_init){
+      equation_system.re_init();
+  }
+  else{
+      equation_system.init();
+  }
+
   libMesh::DofMap &dof_map = system.get_dof_map();
   std::vector<libMesh::dof_id_type> dof_indices;
   for (const auto &elem : mesh.element_ptr_range()) {
-
     dof_map.dof_indices(elem, dof_indices);
     int random_int = rand() % 5;
     system.solution->set(dof_indices[0], 5 - random_int);
@@ -20,21 +33,11 @@ void PopulateRandomIntegers(libMesh::Mesh &mesh,
   system.solution->close();
 }
 
-void AddVariableToSystem(libMesh::EquationSystems &equation_system,
-                         libMesh::LinearImplicitSystem &system,
-                         std::string var_name, bool needs_re_init = false) {
-  system.add_variable(var_name, libMesh::CONSTANT, libMesh::MONOMIAL);
-  if (!needs_re_init) {
-    equation_system.init();
-  } else {
-    equation_system.reinit();
-  }
-}
 int main(int argc, char **argv) {
-  //declaring the system name and variable_name
-  //variable_name would be the variable based on which heuristics would be done
+  // declaring the system name and variable_name
+  // variable_name would be the variable based on which heuristics would be done
   std::string name_of_the_system = "random_solution_field";
-  std::string populated_varibale_name = "random_data";
+  std::string populated_variable_name = "random_data";
 
   // preparing the mesh and the data
   libMesh::LibMeshInit init(argc, argv);
@@ -44,19 +47,12 @@ int main(int argc, char **argv) {
   libMesh::MeshTools::Generation::build_square(mesh, nx, ny, -10.0, 10.0, -10.0,
                                                10.0);
   libMesh::EquationSystems equation_system(mesh);
-  libMesh::LinearImplicitSystem &system =
-      equation_system.add_system<libMesh::LinearImplicitSystem>(
-          name_of_the_system);
-  AddVariableToSystem(equation_system, system, populated_varibale_name);
-  PopulateRandomIntegers(mesh, system);
+  PopulateRandomIntegers(mesh, equation_system, name_of_the_system,
+                         populated_variable_name);
 
   // actual clustering process
-  /* Now the framework presumes I have the mesh and equation_system
-   * and I am fully aware what is the name and type of the system (for now we
-   * are only allowing LinearImplicitSystem) which solution field (name of the
-   * variable) should be */
   EqualNeighborHeuristic demo(mesh, equation_system, name_of_the_system,
-                              populated_varibale_name);
+                              populated_variable_name);
   demo.setTolerance(0.001);
   demo.findCluster();
   demo.captureClusterID();

--- a/test_cases/testMeshAmalgamation.cpp
+++ b/test_cases/testMeshAmalgamation.cpp
@@ -1,0 +1,43 @@
+#include <cmath>
+#include <cstdlib>
+#include <ctime>
+#include <random>
+
+#include "libmesh/mesh_generation.h"
+#include "libmesh/libmesh.h"
+#include "MeshAmalgamationBase.h"
+
+class testMeshAmalgamation:public MeshAmalgamation{
+public:
+    testMeshAmalgamation(libMesh::Mesh &mesh,
+                            libMesh::EquationSystems &equation_system,
+                            std::string system_name): MeshAmalgamation(mesh, equation_system, system_name) {}
+
+    void populateRandomData(){
+        std::vector<libMesh::dof_id_type> dof_indices;
+        for (const auto &elem : _mesh.element_ptr_range()) {
+            _dof_map.dof_indices(elem, dof_indices);
+            int random_int = rand() % 5;
+            _system.solution->set(dof_indices[0], random_int);
+        }
+        _system.solution->close();
+    }
+    bool belongToCluster(libMesh::Elem *elem,libMesh::Elem *neighbor_elem){return true;}
+    //this won't be used at all for this demonstration
+};
+
+int main(int argc, char **argv){
+
+    libMesh::LibMeshInit init(argc, argv);
+    libMesh::Mesh mesh(init.comm());
+    unsigned int nx = 5;
+    unsigned int ny = 5;
+    libMesh::MeshTools::Generation::build_square(mesh, nx, ny, -10.0, 10.0, -10.0,10.0);
+    libMesh::EquationSystems equation_system(mesh);
+
+    testMeshAmalgamation demo (mesh,equation_system,"testMeshAmalgamation_field");
+    demo.addVariableToSystem("random_data");
+    demo.populateRandomData();
+    demo.writeOutputData("testMeshAmalgamation.e");
+}
+


### PR DESCRIPTION
In  PR #3 there is a bug fix in the `MeshAmalgamationBase.cpp` file 
old:   ` _system (_equation_system.add_system<LinearImplicitSystem>(_system_name)),`
new: ` _system (_equation_system.add_system<libMesh::LinearImplicitSystem>(_system_name)),`

PR #6 assumes that's been fixed 

closes #4 