### PR TITLE
chaning the index of the getElementDataFromMesh function

### DIFF
--- a/src/MeshAmalgamationBase.cpp
+++ b/src/MeshAmalgamationBase.cpp
@@ -101,7 +101,7 @@ double MeshAmalgamation::getElementDataFromMesh(const libMesh::Elem *elem) {
   _dof_map.dof_indices(elem, dof_indices, _variable_index);
   _system.solution->get(dof_indices, solution_value);
 
-  return static_cast<double>(solution_value[_variable_index]);
+  return static_cast<double>(solution_value[0]);
 }
 
 void MeshAmalgamation::setNumberOfColors(unsigned int number_of_colors){

--- a/src/MeshAmalgamationBase.cpp
+++ b/src/MeshAmalgamationBase.cpp
@@ -101,7 +101,7 @@ double MeshAmalgamation::getElementDataFromMesh(const libMesh::Elem *elem) {
   _dof_map.dof_indices(elem, dof_indices, _variable_index);
   _system.solution->get(dof_indices, solution_value);
 
-  return static_cast<double>(solution_value[0]);
+  return static_cast<double>(solution_value[_variable_index]);
 }
 
 void MeshAmalgamation::setNumberOfColors(unsigned int number_of_colors){

--- a/test_cases/testEqualNeighborHeuristic.cpp
+++ b/test_cases/testEqualNeighborHeuristic.cpp
@@ -10,7 +10,7 @@
 void PopulateRandomIntegers(libMesh::Mesh &mesh,
                             libMesh::EquationSystems &equation_system,
                             const std::string system_name,
-                            const std::string variable_name,needs_re_init=false) {
+                            const std::string variable_name,bool needs_re_init=false) {
 
   libMesh::LinearImplicitSystem& system =
       equation_system.add_system<libMesh::LinearImplicitSystem>(system_name);


### PR DESCRIPTION
Previously snitch presumed that clustering will happen on a mesh that has only one solution field. 
This PR moves away form that and now snitch can handle multiple solution field in a single mesh. also fixes a tinny bug 

previously: `return static_cast<double>(solution_value[0]);` 
now: `return static_cast<double>(solution_value[_variable_index]);`