### PR TITLE
Set parallel processing of build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           mkdir build
           cd build
           EIGEN3_ROOT=/opt/libmesh/include cmake ..
-          make
+          make -j 8
           echo "Running tests inside the container"
 
       - name: Run Tests


### PR DESCRIPTION
Add `-j` flag to `make` with 8 cores